### PR TITLE
refactor: use single entrypoint for modules

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,21 +8,6 @@
 </head>
 <body>
   <canvas id="app"></canvas>
-  <script type="module">
-    import "./js/utils.js";
-    import "./js/constants.js";
-    import "./js/date-utils.js";
-    import "./js/storage.js";
-    import "./js/srs.js";
-    import "./js/state.js";
-    import "./js/quiz.js";
-    import "./js/speech.js";
-    import "./js/canvas-helpers.js";
-    import "./js/layout.js";
-    import "./js/render.js";
-    import "./js/input-handlers.js";
-    import "./js/tests-smoke.js";
-    import "./js/main.js";
-  </script>
+  <script type="module" src="./js/main.js"></script>
 </body>
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,15 @@
 export let cvs, ctx;
+
+import './utils.js';
+import './constants.js';
+import './date-utils.js';
+import './storage.js';
+import './srs.js';
+import './state.js';
+import './quiz.js';
+import './speech.js';
+import './canvas-helpers.js';
+import './layout.js';
 import {render} from './render.js';
 import {keydownHandler,mousemoveHandler,mousedownHandler,mouseupHandler} from './input-handlers.js';
 import './tests-smoke.js';


### PR DESCRIPTION
## Summary
- load all modules from a single entrypoint by referencing `js/main.js` in `index.html`
- centralize module imports in `js/main.js` with relative paths

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bd99364108321966762f05282ab01