### PR TITLE
feat: add mobile touch support

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,2 +1,27 @@
 html, body { margin:0; padding:0; height:100%; background:#0b0f14; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif; }
 canvas { display:block; width:100vw; height:100vh; }
+
+/* Evita zoom automático ao focar inputs no iOS */
+html { -webkit-text-size-adjust: 100%; }
+
+/* Canvas com melhor gesto de toque (evita double-tap zoom) */
+canvas { touch-action: manipulation; }
+
+/* Input invisível que abre o teclado no mobile */
+#mobileInput{
+  position: fixed;
+  left: -9999px;    /* começa fora da tela */
+  top: 0;
+  width: 1px;
+  height: 1px;
+
+  background: transparent;
+  color: transparent;     /* texto invisível */
+  caret-color: #e7eef7;   /* caret visível */
+  border: none;
+  outline: none;
+
+  opacity: 0.02;          /* 0 esconde o caret em alguns browsers */
+  pointer-events: auto;
+  z-index: 10;
+}

--- a/index.html
+++ b/index.html
@@ -8,6 +8,15 @@
 </head>
 <body>
   <canvas id="app"></canvas>
+  <!-- Input HTML invisível para mobile (abre o teclado) -->
+  <input id="mobileInput"
+         type="text"
+         inputmode="text"
+         autocomplete="off"
+         autocorrect="off"
+         autocapitalize="off"
+         spellcheck="false"
+         aria-label="Resposta" />
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>

--- a/js/constants.js
+++ b/js/constants.js
@@ -7,3 +7,14 @@ export const SIZES={
   hiraganaQuizOffset:40,
   hiraganaManagePx:12
 };
+
+export const IS_MOBILE = /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+
+// Ajustes suaves para fontes/espacamentos no mobile
+if (typeof SIZES !== 'undefined') {
+  SIZES.hiraganaStudyFactor = IS_MOBILE ? 0.11 : (SIZES.hiraganaStudyFactor ?? 0.13);
+  SIZES.hiraganaStudyMin    = IS_MOBILE ? 24   : (SIZES.hiraganaStudyMin ?? 28);
+  SIZES.hiraganaQuizPx      = IS_MOBILE ? 16   : (SIZES.hiraganaQuizPx ?? 18);
+  SIZES.hiraganaManagePx    = IS_MOBILE ? 11   : (SIZES.hiraganaManagePx ?? 12);
+  SIZES.hiraganaQuizOffset  = IS_MOBILE ? 2    : (SIZES.hiraganaQuizOffset ?? 6);
+}

--- a/js/main.js
+++ b/js/main.js
@@ -1,4 +1,3 @@
-// main.js
 import './utils.js';
 import './constants.js';
 import './date-utils.js';
@@ -7,26 +6,90 @@ import './srs.js';
 import './state.js';
 import './quiz.js';
 import './speech.js';
+import './canvas-helpers.js';
 import './layout.js';
 import { render } from './render.js';
 import { keydownHandler, mousemoveHandler, mousedownHandler, mouseupHandler } from './input-handlers.js';
 
-export let cvs, ctx;
+export let cvs = document.getElementById('app'), ctx = cvs.getContext('2d');
 
-function fitCanvas() {
+/* --------- canvas DPR --------- */
+function fitCanvas(){
   const dpr = Math.max(1, Math.floor(window.devicePixelRatio || 1));
   const w = Math.floor(window.innerWidth), h = Math.floor(window.innerHeight);
   cvs.width = w * dpr; cvs.height = h * dpr;
-  cvs.style.width = w + 'px'; cvs.style.height = h + 'px';
-  ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  cvs.style.width = w+'px'; cvs.style.height = h+'px';
+  ctx.setTransform(dpr,0,0,dpr,0,0);
 }
 
-window.addEventListener('DOMContentLoaded', () => {
-  cvs = document.getElementById('app');
-  ctx = cvs.getContext('2d');
+/* --------- MOBILE INPUT --------- */
+const mobileInput = document.getElementById('mobileInput');
+let currentInputRect = null;  // {x,y,w,h} em CSS pixels
 
-  window.addEventListener('resize', fitCanvas);
-  fitCanvas();
+function applyMobileInputRect(rect){
+  currentInputRect = rect;
+  if(!rect){
+    mobileInput.blur();
+    mobileInput.style.left = '-9999px';
+    return;
+  }
+  mobileInput.style.left = rect.x + 'px';
+  mobileInput.style.top  = rect.y + 'px';
+  mobileInput.style.width  = Math.max(1, rect.w) + 'px';
+  mobileInput.style.height = Math.max(34, rect.h) + 'px'; // touch target amigável
+}
+
+// usado pelo render.js para informar o retângulo do campo
+export function setMobileInputRect(rect){
+  applyMobileInputRect(rect);
+}
+
+// (Opcional) sincronizar texto “ao vivo” com o state:
+// -> Se decidir, importe State e faça: State.input = mobileInput.value;
+// Mantemos vazio para não interferir na sua lógica atual.
+mobileInput.addEventListener('input', () => {});
+
+/* --------- TOUCH → MOUSE MAP --------- */
+function firstTouch(e){ return e.touches?.[0] ?? e.changedTouches?.[0]; }
+function toCanvasPoint(t){
+  const rect = cvs.getBoundingClientRect();
+  return { x: t.clientX - rect.left, y: t.clientY - rect.top };
+}
+
+function maybeFocusMobileInput(clientX, clientY){
+  if(!currentInputRect) return;
+  const r = currentInputRect;
+  if (clientX >= r.x && clientX <= r.x + r.w &&
+      clientY >= r.y && clientY <= r.y + r.h) {
+    setTimeout(()=> mobileInput?.focus(), 0);
+  }
+}
+
+cvs.addEventListener('touchstart', (e)=>{
+  const t = firstTouch(e); if(!t) return;
+  maybeFocusMobileInput(t.clientX, t.clientY);
+  const p = toCanvasPoint(t);
+  e.preventDefault();
+  mousedownHandler({ clientX:p.x, clientY:p.y, preventDefault(){}, stopPropagation(){} });
+},{passive:false});
+
+cvs.addEventListener('touchmove', (e)=>{
+  const t = firstTouch(e); if(!t) return;
+  const p = toCanvasPoint(t);
+  e.preventDefault();
+  mousemoveHandler({ clientX:p.x, clientY:p.y, preventDefault(){}, stopPropagation(){} });
+},{passive:false});
+
+cvs.addEventListener('touchend', (e)=>{
+  const t = firstTouch(e); if(!t) return;
+  const p = toCanvasPoint(t);
+  e.preventDefault();
+  mouseupHandler({ clientX:p.x, clientY:p.y, preventDefault(){}, stopPropagation(){} });
+},{passive:false});
+
+/* --------- STARTUP --------- */
+window.addEventListener('DOMContentLoaded', () => {
+  window.addEventListener('resize', fitCanvas); fitCanvas();
 
   window.addEventListener('keydown', keydownHandler);
   cvs.addEventListener('mousemove', mousemoveHandler);

--- a/js/render.js
+++ b/js/render.js
@@ -1,4 +1,4 @@
-import { ctx, cvs } from './main.js';
+import { ctx, cvs, setMobileInputRect } from './main.js';
 import { C, SIZES } from './constants.js';
 import {
   roundRect,
@@ -15,6 +15,7 @@ import { parseAnswers, tick, incTick } from './utils.js';
 
 export function render() {
   incTick();
+  setMobileInputRect(null); // por padrão escondemos; modos sem input mantêm teclado fechado
   const L = layout();
   ctx.clearRect(0, 0, cvs.clientWidth, cvs.clientHeight);
 
@@ -71,6 +72,8 @@ export function render() {
       ctx.fillText('Tradução (PT-BR) — digite e pressione Enter:', L.card.x + 24, ansY - 36);
       const inp = { x: L.card.x + 24, y: ansY - 24, w: L.card.w - 48 - 150, h: 48, label: '', value: State.input, placeholder: 'ex.: olá; boa tarde', focused: true };
       drawInput(inp);
+      // informa ao main.js onde posicionar o input HTML (para abrir teclado no mobile)
+      setMobileInputRect({ x: inp.x, y: inp.y, w: inp.w, h: inp.h });
     }
   }
 
@@ -122,7 +125,7 @@ export function render() {
       ctx.fillText('Sem cartas suficientes. Adicione ⚙ algumas e volte ao Quiz.', L.card.x + L.card.w / 2, L.card.y + L.card.h / 2);
     } else {
       ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-      const romajiSize = Math.max(32, Math.floor(L.card.h * 0.18));
+      const romajiSize = Math.max(28, Math.min(48, Math.floor(L.card.h * 0.18)));
       const romajiY = L.card.y + 70;
       ctx.fillStyle = C.text; ctx.font = `800 ${romajiSize}px system-ui`;
       ctx.fillText(q.current.romaji, L.card.x + L.card.w / 2, romajiY);


### PR DESCRIPTION
## Summary
- support mobile text entry with hidden input and touch gestures
- tweak styles and size constants for better small-screen rendering
- notify main canvas about input position and clamp quiz font sizes

## Testing
- `npm test` *(fails: Could not read package.json)*
- `node js/tests-smoke.js` *(fails: localStorage is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_689be9b93e448321bea5d3b9d39aa230