### PR TITLE
Improve mobile support

### DIFF
--- a/js/input-handlers.js
+++ b/js/input-handlers.js
@@ -1,35 +1,84 @@
-import {cvs} from './main.js';
-import {State,addCardFromForm,checkAnswer,chooseDifficulty,pasteFromClipboard} from './state.js';
-import {layout} from './layout.js';
+import { cvs } from './main.js';
+import { State, addCardFromForm, checkAnswer, chooseDifficulty, pasteFromClipboard } from './state.js';
+import { layout } from './layout.js';
 
-export const mouse={x:0,y:0,down:false};
+export const mouse = { x: 0, y: 0, down: false };
 
-export function keydownHandler(e){
-  if((State.mode==='study'||State.mode==='train'||State.mode==='quiz')&&(e.key==='F5'||(e.ctrlKey&&e.key.toLowerCase()==='r'))){e.preventDefault();return;}
-  if(State.mode==='study'||State.mode==='train'){
-    if(!State.showAnswer){
-      if(e.key==='Enter'){checkAnswer();return;}
-      if(e.key==='Backspace'){State.input=State.input.slice(0,-1);return;}
-      if(e.key.length===1){State.input+=e.key;return;}
-    } else {
-      if(e.key==='1'){chooseDifficulty('dificil'); return;}
-      if(e.key==='2'){chooseDifficulty('medio');  return;}
-      if(e.key==='3'){chooseDifficulty('facil');  return;}
-    }
-  }
-  if(State.mode==='add'){
-    const f=State.focusField||'hiragana';
-    if(e.key==='Tab'){e.preventDefault(); State.focusField= f==='hiragana'?'romaji': f==='romaji'?'pt':'hiragana'; return;}
-    if(e.key==='Enter'){addCardFromForm();return;}
-    if(e.key==='Backspace'){State.addForm[f]=State.addForm[f].slice(0,-1);return;}
-    if(e.key.length===1){State.addForm[f]+=e.key;return;}
-  }
-  if(State.mode==='bulk'){ if((e.ctrlKey||e.metaKey)&&e.key.toLowerCase()==='v'){ pasteFromClipboard(); } }
+const mobileInput = document.createElement('input');
+mobileInput.type = 'text';
+mobileInput.autocomplete = 'off';
+mobileInput.autocapitalize = 'off';
+mobileInput.spellcheck = false;
+mobileInput.style.position = 'fixed';
+mobileInput.style.opacity = '0';
+mobileInput.style.left = '-1000px';
+mobileInput.style.top = '-1000px';
+mobileInput.style.width = '1px';
+mobileInput.style.height = '1px';
+mobileInput.style.pointerEvents = 'none';
+document.body.appendChild(mobileInput);
+
+let mobileCB = null;
+mobileInput.addEventListener('input', () => { if (mobileCB) mobileCB(mobileInput.value); });
+
+export function showMobileInput(value = '', cb) {
+  mobileInput.value = value;
+  mobileCB = cb;
+  mobileInput.style.left = '0px';
+  mobileInput.style.top = '0px';
+  mobileInput.style.pointerEvents = 'none';
+  mobileInput.focus();
+  setTimeout(() => mobileInput.setSelectionRange(mobileInput.value.length, mobileInput.value.length), 0);
 }
 
-export function mousemoveHandler(e){const r=cvs.getBoundingClientRect(); mouse.x=e.clientX-r.left; mouse.y=e.clientY-r.top;}
-export function mousedownHandler(){mouse.down=true; handleClick(mouse.x,mouse.y);}
-export function mouseupHandler(){mouse.down=false;}
+export function hideMobileInput() {
+  mobileCB = null;
+  mobileInput.blur();
+  mobileInput.style.left = '-1000px';
+  mobileInput.style.top = '-1000px';
+  mobileInput.style.pointerEvents = 'none';
+}
 
-function hit(b,x,y){return x>=b.x&&x<=b.x+b.w&&y>=b.y&&y<=b.y+b.h;}
-export function handleClick(x,y){const u=layout(); const all=[...u.buttons,...u.clickZones]; for(const b of all){ if(hit(b,x,y)){ b.onClick&&b.onClick(); return; } } }
+export function keydownHandler(e) {
+  const mobileActive = document.activeElement === mobileInput;
+  if ((State.mode === 'study' || State.mode === 'train' || State.mode === 'quiz') && (e.key === 'F5' || (e.ctrlKey && e.key.toLowerCase() === 'r'))) {
+    e.preventDefault(); return;
+  }
+  if (State.mode === 'study' || State.mode === 'train') {
+    if (!State.showAnswer) {
+      if (e.key === 'Enter') { hideMobileInput(); checkAnswer(); return; }
+      if (mobileActive) return;
+      if (e.key === 'Backspace') { State.input = State.input.slice(0, -1); return; }
+      if (e.key.length === 1) { State.input += e.key; return; }
+    } else {
+      if (e.key === '1') { chooseDifficulty('dificil'); return; }
+      if (e.key === '2') { chooseDifficulty('medio'); return; }
+      if (e.key === '3') { chooseDifficulty('facil'); return; }
+    }
+  }
+  if (State.mode === 'add') {
+    const f = State.focusField || 'hiragana';
+    if (e.key === 'Tab') { e.preventDefault(); State.focusField = f === 'hiragana' ? 'romaji' : f === 'romaji' ? 'pt' : 'hiragana'; showMobileInput(State.addForm[State.focusField], v => { State.addForm[State.focusField] = v; }); return; }
+    if (e.key === 'Enter') { hideMobileInput(); addCardFromForm(); return; }
+    if (mobileActive) return;
+    if (e.key === 'Backspace') { State.addForm[f] = State.addForm[f].slice(0, -1); return; }
+    if (e.key.length === 1) { State.addForm[f] += e.key; return; }
+  }
+  if (State.mode === 'bulk') { if ((e.ctrlKey || e.metaKey) && e.key.toLowerCase() === 'v') { pasteFromClipboard(); } }
+}
+
+export function mousemoveHandler(e) {
+  const r = cvs.getBoundingClientRect();
+  mouse.x = e.clientX - r.left; mouse.y = e.clientY - r.top;
+}
+export function mousedownHandler() { mouse.down = true; handleClick(mouse.x, mouse.y); }
+export function mouseupHandler() { mouse.down = false; }
+
+function hit(b, x, y) { return x >= b.x && x <= b.x + b.w && y >= b.y && y <= b.y + b.h; }
+export function handleClick(x, y) {
+  hideMobileInput();
+  const u = layout();
+  const all = [...u.buttons, ...u.clickZones];
+  for (const b of all) { if (hit(b, x, y)) { b.onClick && b.onClick(); return; } }
+}
+

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,6 +1,7 @@
 import { cvs, ctx } from './main.js';
 import { roundRect } from './canvas-helpers.js';
 import { C, SIZES } from './constants.js';
+import { showMobileInput } from './input-handlers.js';
 import {
   State,
   currentCard,
@@ -34,7 +35,8 @@ export function layout() {
   const streakBox = { x: bar.x + prog.w + 12, y: bar.y - 2, w: 220, h: 22 };
 
   // Botões principais
-  const topBtnW = 112, topBtnH = 36;
+  const topBtnW = Math.max(64, Math.floor((W - pad * 2 - 16 * 4) / 5));
+  const topBtnH = Math.max(32, Math.floor(topBtnW * 0.32));
   const rightBoxW = topBtnW * 5 + 16 * 4;
   const rightBox = { x: W - pad - rightBoxW, y: bar.y - 10, w: rightBoxW, h: topBtnH };
 
@@ -46,7 +48,7 @@ export function layout() {
   buttons.push(btnStudy, btnTrain, btnQuiz, btnSum, btnList);
 
   // Engrenagem (Adicionar)
-  const gear = { x: pad, y: H - pad - 40, w: 40, h: 40, onClick: () => { State.mode = 'add'; State.focusField = 'hiragana'; } };
+  const gear = { x: pad, y: H - pad - 40, w: 40, h: 40, onClick: () => { State.mode = 'add'; State.focusField = 'hiragana'; showMobileInput(State.addForm.hiragana, v => { State.addForm.hiragana = v; }); } };
   clickZones.push(gear);
 
   // Card
@@ -61,7 +63,9 @@ export function layout() {
       { key: 'medio',  label: 'Médio'  },
       { key: 'facil',  label: 'Fácil'  },
     ];
-    const pw = 92, ph = 30, gap = 10;
+    const gap = 10;
+    const ph = Math.max(24, Math.floor(cardH * 0.05));
+    const pw = Math.max(60, Math.floor((cardW - gap * (defs.length - 1) - 48) / defs.length));
     let px = cx + 24, py = cy + 16;
     for (const p of defs) {
       const pill = { x: px, y: py, w: pw, h: ph, label: p.label, active: State.trainFilter === p.key };
@@ -78,6 +82,11 @@ export function layout() {
     if (!State.showAnswer) {
       const btnVer = { x: cx + cardW - 140, y: cy + cardH - 56, w: 120, h: 44, label: 'Verificar', onClick: checkAnswer };
       buttons.push(btnVer);
+      const startY = cy + (State.mode === 'train' ? 72 : 28);
+      const ry = startY + Math.max(SIZES.hiraganaStudyMin, Math.floor(cardH * SIZES.hiraganaStudyFactor)) + 8;
+      let afterY = ry + 36;
+      const ansY = Math.min(cy + cardH - 120, afterY + 16);
+      clickZones.push({ x: cx + 24, y: ansY - 24, w: cardW - 48 - 150, h: 48, onClick: () => { showMobileInput(State.input, v => { State.input = v; }); } });
     } else {
       const bx = cx + cardW - (120 * 3 + 12 * 2) - 16, by = cy + cardH - 56;
       const bHard = { x: bx,                y: by, w: 120, h: 44, label: 'Difícil (1)', fill: C.danger, onClick: () => chooseDifficulty('dificil') };
@@ -101,9 +110,9 @@ export function layout() {
     const bBulk = { x: ix,         y: cy + 372, w: iw,  h: 44, label: 'Colar lista (Importar em massa)', fill: '#334155', onClick: openBulk };
     buttons.push(bTab, bAdd, bBulk);
 
-    clickZones.push({ x: i1.x, y: i1.y, w: i1.w, h: i1.h, onClick: () => { State.focusField = 'hiragana'; } });
-    clickZones.push({ x: i2.x, y: i2.y, w: i2.w, h: i2.h, onClick: () => { State.focusField = 'romaji';   } });
-    clickZones.push({ x: i3.x, y: i3.y, w: i3.w, h: i3.h, onClick: () => { State.focusField = 'pt';       } });
+    clickZones.push({ x: i1.x, y: i1.y, w: i1.w, h: i1.h, onClick: () => { State.focusField = 'hiragana'; showMobileInput(State.addForm.hiragana, v => { State.addForm.hiragana = v; }); } });
+    clickZones.push({ x: i2.x, y: i2.y, w: i2.w, h: i2.h, onClick: () => { State.focusField = 'romaji'; showMobileInput(State.addForm.romaji, v => { State.addForm.romaji = v; }); } });
+    clickZones.push({ x: i3.x, y: i3.y, w: i3.w, h: i3.h, onClick: () => { State.focusField = 'pt'; showMobileInput(State.addForm.pt, v => { State.addForm.pt = v; }); } });
   }
 
   // BULK

--- a/js/main.js
+++ b/js/main.js
@@ -1,6 +1,6 @@
 // main.js
 import './utils.js';
-import './constants.js';
+import { SIZES } from './constants.js';
 import './date-utils.js';
 import './storage.js';
 import './srs.js';
@@ -19,6 +19,10 @@ function fitCanvas() {
   cvs.width = w * dpr; cvs.height = h * dpr;
   cvs.style.width = w + 'px'; cvs.style.height = h + 'px';
   ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+  const scale = Math.min(w / 800, h / 600);
+  SIZES.hiraganaQuizPx = Math.max(20, Math.floor(24 * scale));
+  SIZES.hiraganaQuizOffset = Math.floor(40 * scale);
+  SIZES.hiraganaManagePx = Math.max(10, Math.floor(12 * scale));
 }
 
 window.addEventListener('DOMContentLoaded', () => {
@@ -32,6 +36,22 @@ window.addEventListener('DOMContentLoaded', () => {
   cvs.addEventListener('mousemove', mousemoveHandler);
   cvs.addEventListener('mousedown', mousedownHandler);
   window.addEventListener('mouseup', mouseupHandler);
+
+  cvs.addEventListener('touchstart', (e) => {
+    const t = e.changedTouches[0];
+    mousemoveHandler(t);
+    mousedownHandler();
+    e.preventDefault();
+  }, { passive: false });
+  cvs.addEventListener('touchmove', (e) => {
+    const t = e.changedTouches[0];
+    mousemoveHandler(t);
+    e.preventDefault();
+  }, { passive: false });
+  window.addEventListener('touchend', (e) => {
+    mouseupHandler();
+    e.preventDefault();
+  }, { passive: false });
 
   requestAnimationFrame(render);
 


### PR DESCRIPTION
## Summary
- scale canvas UI and fonts to viewport and add touch events
- provide hidden input for mobile keyboards and sync state
- resize layout buttons/pills and open keyboard on input taps

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689bef61b3d48321ad8e9587eda1d7a2