### PR TITLE
Improve mobile input and responsiveness

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,2 +1,13 @@
 html, body { margin:0; padding:0; height:100%; background:#0b0f14; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif; }
-canvas { display:block; width:100vw; height:100vh; }
+canvas { display:block; width:100vw; height:100vh; touch-action: manipulation; }
+
+/* Reduz overscroll de iOS ao focar o input invisível */
+html, body { overscroll-behavior-y: contain; }
+
+/* Em telas muito estreitas, comprimimos os botões do topo */
+@media (max-width: 420px) {
+  :root{
+    --top-btn-w: 84px;   /* usado no layout.js via fallback numérico */
+    --top-btn-h: 34px;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -2,12 +2,23 @@
 <html lang="pt-BR">
 <head>
   <meta charset="utf-8" />
-  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
   <title>Flashcards JP↔PT — Canvas</title>
   <link rel="stylesheet" href="css/style.css" />
 </head>
 <body>
   <canvas id="app"></canvas>
+
+  <!-- INPUT INVISÍVEL para abrir teclado no mobile -->
+  <input id="mobileInput"
+         type="text"
+         inputmode="text"
+         enterkeyhint="go"
+         autocomplete="off"
+         autocapitalize="off"
+         autocorrect="off"
+         spellcheck="false"
+         style="position:fixed; left:-9999px; top:-9999px; width:1px; height:1px; opacity:0.02; background:transparent; color:transparent; caret-color:#7ee7f3; border:0; outline:0; z-index:10; pointer-events:auto;" />
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>

--- a/js/constants.js
+++ b/js/constants.js
@@ -1,9 +1,16 @@
-export const C={card:'#121826',accent:'#43b6ff',accent2:'#7cffad',text:'#e7eef7',sub:'#9fb3c8',danger:'#ff6b6b',warn:'#ffd166',stroke:'rgba(255,255,255,0.08)'};
+import { IS_MOBILE } from './main.js';
 
-export const SIZES={
-  hiraganaStudyFactor:0.13,
-  hiraganaStudyMin:28,
-  hiraganaQuizPx:24,
-  hiraganaQuizOffset:40,
-  hiraganaManagePx:12
+export const C = { card:'#121826',accent:'#43b6ff',accent2:'#7cffad',text:'#e7eef7',sub:'#9fb3c8',danger:'#ff6b6b',warn:'#ffd166',stroke:'rgba(255,255,255,0.08)' };
+
+export const SIZES = {
+  // estudo/treino
+  hiraganaStudyFactor: IS_MOBILE ? 0.10 : 0.13,
+  hiraganaStudyMin:    IS_MOBILE ? 22   : 28,
+
+  // quiz
+  hiraganaQuizPx:      IS_MOBILE ? 16   : 18,
+  hiraganaQuizOffset:  IS_MOBILE ? 2    : 6,
+
+  // tabela "Lista"
+  hiraganaManagePx:    IS_MOBILE ? 11   : 12
 };

--- a/js/layout.js
+++ b/js/layout.js
@@ -1,7 +1,6 @@
-import { cvs, ctx } from './main.js';
+import { ctx, cvs, IS_MOBILE, mobileInput } from './main.js';
 import { roundRect } from './canvas-helpers.js';
 import { C, SIZES } from './constants.js';
-import { showMobileInput } from './input-handlers.js';
 import {
   State,
   currentCard,
@@ -21,8 +20,8 @@ import { startQuizQuestion, selectQuizOption, nextQuiz } from './quiz.js';
 import { speakJP } from './speech.js';
 
 export function layout() {
-  const W = cvs.clientWidth, H = cvs.clientHeight;
-  const pad = Math.max(16, Math.floor(W * 0.02));
+    const W = cvs.clientWidth, H = cvs.clientHeight;
+    const pad = Math.max(12, Math.floor(W * 0.02));
   const cardW = Math.min(880, W - pad * 2);
   const cardH = Math.min(560, H - pad * 3 - 64);
   const cx = (W - cardW) / 2, cy = pad * 2;
@@ -34,10 +33,10 @@ export function layout() {
   const prog = { x: bar.x, y: bar.y, w: Math.min(420, bar.w * 0.55), h: 16 };
   const streakBox = { x: bar.x + prog.w + 12, y: bar.y - 2, w: 220, h: 22 };
 
-  // Botões principais
-  const topBtnW = Math.max(64, Math.floor((W - pad * 2 - 16 * 4) / 5));
-  const topBtnH = Math.max(32, Math.floor(topBtnW * 0.32));
-  const rightBoxW = topBtnW * 5 + 16 * 4;
+    // Botões principais
+    const topBtnW = IS_MOBILE ? 84 : 112;
+    const topBtnH = IS_MOBILE ? 34 : 36;
+    const rightBoxW = topBtnW * 5 + 16 * 4;
   const rightBox = { x: W - pad - rightBoxW, y: bar.y - 10, w: rightBoxW, h: topBtnH };
 
   const btnStudy = { x: rightBox.x, y: rightBox.y, w: topBtnW, h: topBtnH, label: 'Estudar', onClick: () => { State.mode = 'study'; pickNext(); } };
@@ -48,7 +47,7 @@ export function layout() {
   buttons.push(btnStudy, btnTrain, btnQuiz, btnSum, btnList);
 
   // Engrenagem (Adicionar)
-  const gear = { x: pad, y: H - pad - 40, w: 40, h: 40, onClick: () => { State.mode = 'add'; State.focusField = 'hiragana'; showMobileInput(State.addForm.hiragana, v => { State.addForm.hiragana = v; }); } };
+    const gear = { x: pad, y: H - pad - 40, w: 40, h: 40, onClick: () => { State.mode = 'add'; State.focusField = 'hiragana'; if (IS_MOBILE && mobileInput) { mobileInput.value = State.addForm.hiragana || ''; mobileInput.focus(); const v = mobileInput.value || ''; mobileInput.setSelectionRange(v.length, v.length); } } };
   clickZones.push(gear);
 
   // Card
@@ -86,7 +85,6 @@ export function layout() {
       const ry = startY + Math.max(SIZES.hiraganaStudyMin, Math.floor(cardH * SIZES.hiraganaStudyFactor)) + 8;
       let afterY = ry + 36;
       const ansY = Math.min(cy + cardH - 120, afterY + 16);
-      clickZones.push({ x: cx + 24, y: ansY - 24, w: cardW - 48 - 150, h: 48, onClick: () => { showMobileInput(State.input, v => { State.input = v; }); } });
     } else {
       const bx = cx + cardW - (120 * 3 + 12 * 2) - 16, by = cy + cardH - 56;
       const bHard = { x: bx,                y: by, w: 120, h: 44, label: 'Difícil (1)', fill: C.danger, onClick: () => chooseDifficulty('dificil') };
@@ -110,9 +108,9 @@ export function layout() {
     const bBulk = { x: ix,         y: cy + 372, w: iw,  h: 44, label: 'Colar lista (Importar em massa)', fill: '#334155', onClick: openBulk };
     buttons.push(bTab, bAdd, bBulk);
 
-    clickZones.push({ x: i1.x, y: i1.y, w: i1.w, h: i1.h, onClick: () => { State.focusField = 'hiragana'; showMobileInput(State.addForm.hiragana, v => { State.addForm.hiragana = v; }); } });
-    clickZones.push({ x: i2.x, y: i2.y, w: i2.w, h: i2.h, onClick: () => { State.focusField = 'romaji'; showMobileInput(State.addForm.romaji, v => { State.addForm.romaji = v; }); } });
-    clickZones.push({ x: i3.x, y: i3.y, w: i3.w, h: i3.h, onClick: () => { State.focusField = 'pt'; showMobileInput(State.addForm.pt, v => { State.addForm.pt = v; }); } });
+    clickZones.push({ x: i1.x, y: i1.y, w: i1.w, h: i1.h, onClick: () => { State.focusField = 'hiragana'; if (IS_MOBILE && mobileInput) { mobileInput.value = State.addForm.hiragana || ''; mobileInput.focus(); const v = mobileInput.value || ''; mobileInput.setSelectionRange(v.length, v.length); } } });
+    clickZones.push({ x: i2.x, y: i2.y, w: i2.w, h: i2.h, onClick: () => { State.focusField = 'romaji'; if (IS_MOBILE && mobileInput) { mobileInput.value = State.addForm.romaji || ''; mobileInput.focus(); const v = mobileInput.value || ''; mobileInput.setSelectionRange(v.length, v.length); } } });
+    clickZones.push({ x: i3.x, y: i3.y, w: i3.w, h: i3.h, onClick: () => { State.focusField = 'pt'; if (IS_MOBILE && mobileInput) { mobileInput.value = State.addForm.pt || ''; mobileInput.focus(); const v = mobileInput.value || ''; mobileInput.setSelectionRange(v.length, v.length); } } });
   }
 
   // BULK

--- a/js/render.js
+++ b/js/render.js
@@ -1,4 +1,4 @@
-import { ctx, cvs } from './main.js';
+import { ctx, cvs, syncMobileInput, IS_MOBILE } from './main.js';
 import { C, SIZES } from './constants.js';
 import {
   roundRect,
@@ -50,15 +50,21 @@ export function render() {
     } else {
       const startY = L.card.y + (State.mode === 'train' ? 72 : 28);
       ctx.fillStyle = C.text;
-      ctx.font = `700 ${Math.max(SIZES.hiraganaStudyMin, Math.floor(L.card.h * SIZES.hiraganaStudyFactor))}px system-ui`;
+      const base = Math.min(L.card.w, L.card.h);
+      const hiraSize = Math.min(
+        Math.max(SIZES.hiraganaStudyMin, Math.floor(L.card.h * SIZES.hiraganaStudyFactor)),
+        IS_MOBILE ? Math.floor(base * 0.3) : Infinity
+      );
+      ctx.font = `700 ${hiraSize}px system-ui`;
       ctx.textAlign = 'center'; ctx.textBaseline = 'top';
       ctx.fillText(currentCard.hiragana, L.card.x + L.card.w / 2, startY);
 
-      ctx.fillStyle = C.sub; ctx.font = '600 22px system-ui';
-      const ry = startY + Math.max(SIZES.hiraganaStudyMin, Math.floor(L.card.h * SIZES.hiraganaStudyFactor)) + 8;
+      const ry = startY + hiraSize + 8;
+      const romajiSize = Math.min(22, IS_MOBILE ? Math.floor(base * 0.12) : 22);
+      ctx.fillStyle = C.sub; ctx.font = `600 ${romajiSize}px system-ui`;
       ctx.fillText(currentCard.romaji, L.card.x + L.card.w / 2, ry);
 
-      let afterY = ry + 36;
+      let afterY = ry + romajiSize + 14;
       if (State.showAnswer) {
         const answers = parseAnswers(currentCard.pt);
         ctx.fillStyle = C.sub; ctx.font = '600 14px system-ui'; ctx.fillText('Respostas aceitas:', L.card.x + L.card.w / 2, afterY);
@@ -71,7 +77,12 @@ export function render() {
       ctx.fillText('Tradução (PT-BR) — digite e pressione Enter:', L.card.x + 24, ansY - 36);
       const inp = { x: L.card.x + 24, y: ansY - 24, w: L.card.w - 48 - 150, h: 48, label: '', value: State.input, placeholder: 'ex.: olá; boa tarde', focused: true };
       drawInput(inp);
+      State.lastInputRect = { x: inp.x, y: inp.y, w: inp.w, h: inp.h };
+      syncMobileInput(State.lastInputRect);
     }
+  } else {
+    State.lastInputRect = null;
+    syncMobileInput(null);
   }
 
   if (State.mode === 'add') {
@@ -122,7 +133,11 @@ export function render() {
       ctx.fillText('Sem cartas suficientes. Adicione ⚙ algumas e volte ao Quiz.', L.card.x + L.card.w / 2, L.card.y + L.card.h / 2);
     } else {
       ctx.textAlign = 'center'; ctx.textBaseline = 'top';
-      const romajiSize = Math.max(32, Math.floor(L.card.h * 0.18));
+      const base = Math.min(L.card.w, L.card.h);
+      const romajiSize = Math.min(
+        Math.max(28, Math.floor(L.card.h * 0.18)),
+        IS_MOBILE ? Math.floor(base * 0.22) : Infinity
+      );
       const romajiY = L.card.y + 70;
       ctx.fillStyle = C.text; ctx.font = `800 ${romajiSize}px system-ui`;
       ctx.fillText(q.current.romaji, L.card.x + L.card.w / 2, romajiY);

--- a/js/state.js
+++ b/js/state.js
@@ -13,11 +13,12 @@ export const State={
   focusField:null,
   addForm:{hiragana:'',romaji:'',pt:''},
   message:'',
-  manage:{page:0,pageSize:10,selected:null,sort:'due'},
-  bulkText:'',
-  trainFilter:'todas',
-  quiz:{current:null, options:[], correctIndex:-1, selectedIndex:-1}
-};
+    manage:{page:0,pageSize:10,selected:null,sort:'due'},
+    bulkText:'',
+    trainFilter:'todas',
+    quiz:{current:null, options:[], correctIndex:-1, selectedIndex:-1},
+    lastInputRect:null
+  };
 
 export let currentCard=null;
 


### PR DESCRIPTION
## Summary
- add meta viewport and hidden input to enable mobile typing
- size buttons and fonts responsively for small screens
- sync invisible input with app state and handle mobile taps

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_689bf4df09d0832185f45cf075431dc1