### PR TITLE
fix: import missing modules for input handlers

### DIFF
--- a/js/input-handlers.js
+++ b/js/input-handlers.js
@@ -1,5 +1,20 @@
-import { IS_MOBILE, mobileInput, syncMobileInput } from './main.js';
-import { State } from './state.js';
+import {
+  IS_MOBILE,
+  cvs,
+  mobileInput,
+  bulkTextarea,
+  hideMobileInput,
+  hideBulkTextarea,
+  syncMobileInput
+} from './main.js';
+import {
+  State,
+  checkAnswer,
+  chooseDifficulty,
+  addCardFromForm,
+  pasteFromClipboard
+} from './state.js';
+import { layout } from './layout.js';
 
 export const mouse = { x: 0, y: 0, down: false };
 


### PR DESCRIPTION
## Summary
- import missing helpers from main.js and state.js
- wire layout module into click handler to avoid reference errors

## Testing
- `node js/tests-smoke.js` *(fails: TypeError: Cannot read properties of undefined)*

------
https://chatgpt.com/codex/tasks/task_e_689c0c5efb8c832180d9c6ea74bee3ec