### PR TITLE
fix: guard canvas access in mouse move

### DIFF
--- a/js/input-handlers.js
+++ b/js/input-handlers.js
@@ -1,5 +1,20 @@
-import { IS_MOBILE, mobileInput, syncMobileInput } from './main.js';
-import { State } from './state.js';
+import {
+  IS_MOBILE,
+  cvs,
+  mobileInput,
+  bulkTextarea,
+  hideMobileInput,
+  hideBulkTextarea,
+  syncMobileInput
+} from './main.js';
+import {
+  State,
+  checkAnswer,
+  chooseDifficulty,
+  addCardFromForm,
+  pasteFromClipboard
+} from './state.js';
+import { layout } from './layout.js';
 
 export const mouse = { x: 0, y: 0, down: false };
 
@@ -44,8 +59,11 @@ export function keydownHandler(e) {
 }
 
 export function mousemoveHandler(e) {
-  const r = cvs.getBoundingClientRect();
-  mouse.x = e.clientX - r.left; mouse.y = e.clientY - r.top;
+  const can = cvs || document.getElementById('app');
+  if (!can) return;
+  const r = can.getBoundingClientRect();
+  mouse.x = e.clientX - r.left;
+  mouse.y = e.clientY - r.top;
 }
 export function mousedownHandler() { mouse.down = true; handleClick(mouse.x, mouse.y); }
 export function mouseupHandler() { mouse.down = false; }

--- a/js/layout.js
+++ b/js/layout.js
@@ -2,7 +2,8 @@ import { cvs } from './main.js';
 import { SIZES } from './constants.js';
 
 export function layout(){
-  const W = cvs.clientWidth, H = cvs.clientHeight;
+  const W = cvs?.clientWidth || 800;
+  const H = cvs?.clientHeight || 600;
   const pad = Math.max(12, Math.floor(W*0.02));
 
   const safeTop = pad + SIZES.headerPadY;


### PR DESCRIPTION
## Summary
- avoid `getBoundingClientRect` errors when canvas is missing
- allow layout to run without an attached canvas element

## Testing
- `node js/tests-smoke.js` *(fails: Assertion failed: gear presente; layout inclui os 4 botões do quiz; layout inclui Próximo/Pular)*

------
https://chatgpt.com/codex/tasks/task_e_689c0c5efb8c832180d9c6ea74bee3ec