### PR TITLE
Reorganiza camadas de UI e responsividade móvel

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1,13 +1,82 @@
-html, body { margin:0; padding:0; height:100%; background:#0b0f14; font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif; }
-canvas { display:block; width:100vw; height:100vh; touch-action: manipulation; }
+:root {
+  --z-bg: 0;
+  --z-content: 10;
+  --z-hud: 20;
+  --z-fab: 30;
+  --z-menu: 40;
+  --z-toast: 50;
 
-/* Reduz overscroll de iOS ao focar o input invisível */
-html, body { overscroll-behavior-y: contain; }
+  --safe-top: env(safe-area-inset-top);
+  --safe-right: env(safe-area-inset-right);
+  --safe-bottom: env(safe-area-inset-bottom);
+  --safe-left: env(safe-area-inset-left);
+}
+
+html, body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: #0b0f14;
+  font-family: system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, sans-serif;
+  overscroll-behavior-y: contain;
+  overflow: hidden;
+}
+
+canvas {
+  display: block;
+  width: 100vw;
+  height: 100vh;
+  touch-action: manipulation;
+  position: fixed;
+  inset: 0;
+  z-index: var(--z-bg);
+}
+
+#ui-layer {
+  position: fixed;
+  inset: 0;
+  padding: var(--safe-top) var(--safe-right) var(--safe-bottom) var(--safe-left);
+  z-index: var(--z-content);
+  pointer-events: none;
+}
+
+.mobile-input {
+  position: fixed;
+  left: -9999px;
+  top: -9999px;
+  width: 1px;
+  height: 1px;
+  opacity: 0.02;
+  background: transparent;
+  color: transparent;
+  caret-color: #7ee7f3;
+  border: 0;
+  outline: 0;
+  z-index: var(--z-menu);
+  pointer-events: auto;
+}
+
+/* Generic overlay layers */
+.hud { position: absolute; z-index: var(--z-hud); pointer-events: none; }
+.fab { position: fixed; z-index: var(--z-fab); pointer-events: auto; right: calc(16px + var(--safe-right)); bottom: calc(16px + var(--safe-bottom)); }
+.menu-backdrop { position: fixed; inset: 0; background: rgba(0,0,0,0.5); z-index: var(--z-menu); display: flex; align-items: center; justify-content: center; pointer-events: auto; }
+.menu { background: #1f2937; border-radius: 12px; width: min(92vw, 640px); max-width: 100%; padding: 16px; display: flex; flex-direction: column; gap: 8px; }
+.menu button { width: 100%; }
+.snackbar { position: fixed; left: 50%; transform: translateX(-50%); bottom: calc(var(--safe-bottom) + 72px); z-index: var(--z-toast); pointer-events: auto; }
+
+@media (min-width: 481px) and (max-width: 1024px) {
+  .menu { width: 480px; }
+}
+
+@media (min-width: 1025px) {
+  .menu { width: 480px; }
+}
 
 /* Em telas muito estreitas, comprimimos os botões do topo */
 @media (max-width: 420px) {
-  :root{
+  :root {
     --top-btn-w: 84px;   /* usado no layout.js via fallback numérico */
     --top-btn-h: 34px;
   }
 }
+

--- a/index.html
+++ b/index.html
@@ -8,17 +8,18 @@
 </head>
 <body>
   <canvas id="app"></canvas>
-
-  <!-- INPUT INVISÍVEL para abrir teclado no mobile -->
-  <input id="mobileInput"
-         type="text"
-         inputmode="text"
-         enterkeyhint="go"
-         autocomplete="off"
-         autocapitalize="off"
-         autocorrect="off"
-         spellcheck="false"
-         style="position:fixed; left:-9999px; top:-9999px; width:1px; height:1px; opacity:0.02; background:transparent; color:transparent; caret-color:#7ee7f3; border:0; outline:0; z-index:10; pointer-events:auto;" />
+  <div id="ui-layer">
+    <!-- INPUT INVISÍVEL para abrir teclado no mobile -->
+    <input id="mobileInput"
+           class="mobile-input"
+           type="text"
+           inputmode="text"
+           enterkeyhint="go"
+           autocomplete="off"
+           autocapitalize="off"
+           autocorrect="off"
+           spellcheck="false" />
+  </div>
   <script type="module" src="./js/main.js"></script>
 </body>
 </html>

--- a/js/layout.js
+++ b/js/layout.js
@@ -22,15 +22,20 @@ import { speakJP } from './speech.js';
 export function layout() {
     const W = cvs ? cvs.clientWidth : 800,
           H = cvs ? cvs.clientHeight : 600;
+    const cs = typeof window !== 'undefined' ? getComputedStyle(document.documentElement) : null;
+    const safeTop = cs ? parseInt(cs.getPropertyValue('--safe-top')) || 0 : 0;
+    const safeRight = cs ? parseInt(cs.getPropertyValue('--safe-right')) || 0 : 0;
+    const safeBottom = cs ? parseInt(cs.getPropertyValue('--safe-bottom')) || 0 : 0;
+    const safeLeft = cs ? parseInt(cs.getPropertyValue('--safe-left')) || 0 : 0;
     const pad = Math.max(12, Math.floor(W * 0.02));
-  const cardW = Math.min(880, W - pad * 2);
-  const cardH = Math.min(560, H - pad * 3 - 64);
-  const cx = (W - cardW) / 2, cy = pad * 2;
+  const cardW = Math.min(880, W - pad * 2 - safeLeft - safeRight);
+  const cardH = Math.min(560, H - pad * 3 - 64 - safeTop - safeBottom);
+  const cx = safeLeft + (W - safeLeft - safeRight - cardW) / 2, cy = pad * 2 + safeTop;
 
   const buttons = [], clickZones = [], inputs = [];
 
   // Barra superior
-  const bar = { x: pad, y: pad, w: W - pad * 2, h: 20 };
+  const bar = { x: pad + safeLeft, y: pad + safeTop, w: W - pad * 2 - safeLeft - safeRight, h: 20 };
   const prog = { x: bar.x, y: bar.y, w: Math.min(420, bar.w * 0.55), h: 16 };
   const streakBox = { x: bar.x + prog.w + 12, y: bar.y - 2, w: 220, h: 22 };
 
@@ -38,7 +43,7 @@ export function layout() {
     const topBtnW = IS_MOBILE ? 84 : 112;
     const topBtnH = IS_MOBILE ? 34 : 36;
     const rightBoxW = topBtnW * 5 + 16 * 4;
-  const rightBox = { x: W - pad - rightBoxW, y: bar.y - 10, w: rightBoxW, h: topBtnH };
+  const rightBox = { x: W - pad - safeRight - rightBoxW, y: bar.y - 10, w: rightBoxW, h: topBtnH };
 
   const btnStudy = { x: rightBox.x, y: rightBox.y, w: topBtnW, h: topBtnH, label: 'Estudar', onClick: () => { State.mode = 'study'; pickNext(); } };
   const btnTrain = { x: rightBox.x + topBtnW + 16, y: rightBox.y, w: topBtnW, h: topBtnH, label: 'Treinar', fill: '#0ea5e9', onClick: () => { State.mode = 'train'; pickNextTrain(); } };
@@ -48,7 +53,7 @@ export function layout() {
   buttons.push(btnStudy, btnTrain, btnQuiz, btnSum, btnList);
 
   // Engrenagem (Adicionar)
-    const gear = { x: pad, y: H - pad - 40, w: 40, h: 40, onClick: () => { State.mode = 'add'; State.focusField = 'hiragana'; if (IS_MOBILE && mobileInput) { mobileInput.value = State.addForm.hiragana || ''; mobileInput.focus(); const v = mobileInput.value || ''; mobileInput.setSelectionRange(v.length, v.length); } } };
+    const gear = { x: pad + safeLeft, y: H - pad - 40 - safeBottom, w: 40, h: 40, onClick: () => { State.mode = 'add'; State.focusField = 'hiragana'; if (IS_MOBILE && mobileInput) { mobileInput.value = State.addForm.hiragana || ''; mobileInput.focus(); const v = mobileInput.value || ''; mobileInput.setSelectionRange(v.length, v.length); } } };
   clickZones.push(gear);
 
   // Card


### PR DESCRIPTION
## Summary
- Adiciona contêiner fixo `#ui-layer` para hospedar HUD, menus e snackbar
- Define variáveis de `z-index` e áreas seguras com `env()`
- Ajusta cálculo de layout para considerar `safe-area` e manter HUD/FAB visíveis

## Testing
- `node js/tests-smoke.js`


------
https://chatgpt.com/codex/tasks/task_e_689c264321208321a88c2944957f25ad